### PR TITLE
remove dynamic highcharts loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>flipside.js</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <script src="flipside-v1.10.0.js"></script>
+    <script src="flipside-v1.11.0.js"></script>
     <style>
       body {
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flipside-js",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "FlipsideJS provides a library embeddable widgets that display data from the Flipside Platform API, including FCAS.",
   "main": "index.js",
   "scripts": {

--- a/src/chart/index.tsx
+++ b/src/chart/index.tsx
@@ -8,13 +8,15 @@ import CustomLinks from "../components/customLinks";
 import * as css from "./style.css";
 import NoDataMessage from "../components/noDataMessage";
 
-let Highcharts: any;
-if (!window.Highcharts) {
-  Highcharts = require("highcharts/highstock");
-  require("highcharts/modules/exporting")(Highcharts);
-} else {
-  Highcharts = window.Highcharts;
-}
+import Highcharts from "highcharts/highstock";
+require("highcharts/modules/exporting")(Highcharts);
+// let Highcharts: any;
+// // if (!window.Highcharts) {
+//   Highcharts = require("highcharts/highstock");
+//   require("highcharts/modules/exporting")(Highcharts);
+// } else {
+//   Highcharts = window.Highcharts;
+// }
 
 type ChartType = "line" | "bar";
 type ChartAxis = "left" | "right";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { defaultsWithoutArrays } from "./utils";
 import Spectrum, { Props as SpectrumProps } from "./spectrum";
 import MultiTable, { Props as MultiTableProps } from "./multiTable";
 import Score, { Props as ScoreProps } from "./score";
+import Chart, { Props as ChartProps } from "./chart";
 
 export default class Flipside {
   api: API;
@@ -34,9 +35,6 @@ export default class Flipside {
   }
 
   async chart(el: string, opts: any) {
-    const {
-      default: Chart
-    } = await import(/* webpackChunkName: "chart" */ "./chart");
     render(<Chart {...opts} api={this.api} />, document.getElementById(el));
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 const path = require("path");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const version = require("./package.json").version;
-const filename = `flipside-v${version}.js`;
 
 const PUBLIC_PATH =
   process.env.NODE_ENV === "development"
@@ -11,13 +10,11 @@ const PUBLIC_PATH =
 module.exports = {
   entry: "./src/index.tsx",
   output: {
-    filename: filename,
-    chunkFilename: `flipside-[name]-v${version}.js`,
+    filename: `flipside-v${version}.js`,
     path: path.resolve(__dirname, "dist"),
     publicPath: PUBLIC_PATH
   },
   mode: "development",
-  devtool: "inline-source-map",
   resolve: {
     extensions: [".tsx", ".ts", ".js"]
   },


### PR DESCRIPTION
This PR removes  dynamic loading for the chart component due it it breaking when used in other webpack contexts.

Version bumped to 1.11.0